### PR TITLE
Clean up hard-coded paths and ports, print logs from all containers

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -38,7 +38,7 @@ func NewFactory(baseName string) Factory {
 	}
 
 	f.flags.StringVar(&f.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use to talk to the Kubernetes apiserver. If unset, try the environment variable KUBECONFIG, as well as in-cluster configuration")
-	f.flags.Uint16Var(&f.httpPort, "httpPort", uint16(defaultHttpPort), fmt.Sprintf("Port to serve charts on.  Default %v", defaultHttpPort))
+	f.flags.Uint16Var(&f.httpPort, "http-port", uint16(defaultHttpPort), fmt.Sprintf("Port to serve charts on.", defaultHttpPort))
 
 	return f
 }

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -1,9 +1,15 @@
 package client
 
 import (
+	"fmt"
+
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/spf13/pflag"
+)
+
+const (
+	defaultHttpPort = 3000
 )
 
 // Factory knows how to create a Kubernetes client.
@@ -13,12 +19,15 @@ type Factory interface {
 	// KubeClient returns a Kubernetes client. It uses the following priority to specify the cluster
 	// configuration: --kubeconfig flag, KUBECONFIG environment variable, in-cluster configuration.
 	Client() (kubernetes.Interface, error)
+	// Port returns the port to listen on
+	Port() uint16
 }
 
 type factory struct {
 	flags      *pflag.FlagSet
 	kubeconfig string
 	baseName   string
+	httpPort   uint16
 }
 
 // NewFactory returns a Factory.
@@ -29,6 +38,7 @@ func NewFactory(baseName string) Factory {
 	}
 
 	f.flags.StringVar(&f.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use to talk to the Kubernetes apiserver. If unset, try the environment variable KUBECONFIG, as well as in-cluster configuration")
+	f.flags.Uint16Var(&f.httpPort, "httpPort", uint16(defaultHttpPort), fmt.Sprintf("Port to serve charts on.  Default %v", defaultHttpPort))
 
 	return f
 }
@@ -48,4 +58,8 @@ func (f *factory) Client() (kubernetes.Interface, error) {
 		return nil, err
 	}
 	return client, nil
+}
+
+func (f *factory) Port() uint16 {
+	return f.httpPort
 }

--- a/pkg/cmd/kubechart/kubechart.go
+++ b/pkg/cmd/kubechart/kubechart.go
@@ -46,7 +46,7 @@ func run(c *cobra.Command, f client.Factory) error {
 		return err
 	}
 	informerFactory.Start(stopCh)
-	go ui.Run(eventStore, client)
+	go ui.Run(eventStore, client, f.Port())
 	if err = controller.Run(4, stopCh); err != nil {
 		return err
 	}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -12,7 +12,33 @@ import (
 	"github.com/sjenning/kubechart/pkg/event"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func printOneLog(client kubernetes.Interface, w http.ResponseWriter, name, namespace, container string, idx, total int) error {
+	pod := client.CoreV1().Pods(namespace)
+	if total > 1 {
+		io.WriteString(w, "================================================================\n")
+		io.WriteString(w, fmt.Sprintf("Container %d/%d: %s\n", idx + 1, total, container))
+		io.WriteString(w, "================================================================\n\n")
+	}
+	req := pod.GetLogs(name, &v1.PodLogOptions{Container: container})
+	podLogs, err := req.Stream()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return err
+	}
+	defer podLogs.Close()
+	_, err = io.Copy(w, podLogs)
+	if total > 1 && idx < total - 1 {
+		io.WriteString(w, "\n\n")
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return err
+	}
+	return nil
+}
 
 func Run(store event.Store, client kubernetes.Interface, port uint16) {
 	r := mux.NewRouter()
@@ -25,16 +51,20 @@ func Run(store event.Store, client kubernetes.Interface, port uint16) {
 	r.HandleFunc("/logs/{namespace}/{podname}", func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		namespace, podname := vars["namespace"], vars["podname"]
-		req := client.CoreV1().Pods(namespace).GetLogs(podname, &v1.PodLogOptions{})
-		podLogs, err := req.Stream()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer podLogs.Close()
-		_, err = io.Copy(w, podLogs)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		pod := client.CoreV1().Pods(namespace)
+		pods, _ := pod.List(metav1.ListOptions{})
+		for _, item := range pods.Items {
+			if item.Name == podname {
+				cCount := len(item.Spec.Containers)
+				for idx, container := range item.Spec.Containers {
+					_ = printOneLog(client, w, podname, namespace, container.Name, idx, cCount)
+					if err != nil {
+						io.WriteString(w, fmt.Sprintf("Error: %#+v", err))
+						break
+					}
+				}
+				break
+			}
 		}
 	})
 	glog.Infof(fmt.Sprintf("Listening on :%d", port))

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -1,8 +1,11 @@
 package ui
 
 import (
+	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
@@ -11,9 +14,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func Run(store event.Store, client kubernetes.Interface) {
+func Run(store event.Store, client kubernetes.Interface, port uint16) {
 	r := mux.NewRouter()
-	r.Handle("/", http.FileServer(http.Dir("./static")))
+	path, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		path = "."
+	}
+	r.Handle("/", http.FileServer(http.Dir(fmt.Sprintf("%s/static", path))))
 	r.HandleFunc("/data.json", store.JSONHandler)
 	r.HandleFunc("/logs/{namespace}/{podname}", func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -30,6 +37,6 @@ func Run(store event.Store, client kubernetes.Interface) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	})
-	glog.Infof("Listening on :3000")
-	http.ListenAndServe(":3000", r)
+	glog.Infof(fmt.Sprintf("Listening on :%d", port))
+	http.ListenAndServe(fmt.Sprintf(":%d", port), r)
 }

--- a/static/index.html
+++ b/static/index.html
@@ -18,12 +18,13 @@
 <div id="chart"></div>
 
 <script>
+var loc = window.location.href;
 var data = fetch('./data.json')
 	.then(response => response.json())
 	.then(data => {
 		const el = document.querySelector('#chart');
 
-		var segmentFunc = function(segment){window.open("http://localhost:3000/logs/"+segment.group+"/"+segment.label)}
+		var segmentFunc = function(segment){window.open(loc+"logs/"+segment.group+"/"+segment.label)}
 		const myChart = TimelinesChart();
 		var ordinalScale = d3.scaleOrdinal()
 			.domain(['Pending','ContainerCreating','Running','Completed','Succeeded','Deleted', 'Error','CrashLoopBackOff','ErrImagePull','ErrImagePullBackOff', 'OOMKilled', 'Evicted'])


### PR DESCRIPTION
Don't hardcode port (3000), static data location (./, assumes that kubechart is run from current directory), and URL (localhost:3000).

Also report logs from all containers in a pod.