### PR TITLE
revert ImplicitDeleted back to Deleted

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -132,7 +132,7 @@ func (c *Controller) syncHandler(key string) error {
 		if errors.IsNotFound(err) {
 			// pod is deleted
 			glog.Infof("pod %s is deleted", name)
-			c.eventStore.Add(namespace, name, "ImplicitDeleted", "")
+			c.eventStore.Add(namespace, name, "Deleted", "")
 			return nil
 		}
 	}


### PR DESCRIPTION
didn't see this change when it went in #3 

`Deleted` is just as (or more) clear than `ImplicitDeleted`, plus it needs to match here

https://github.com/sjenning/kubechart/blob/master/static/index.html#L30-L31

@RobertKrawitz 